### PR TITLE
App keywords and improved German translation

### DIFF
--- a/app/assistants/main-assistant.js
+++ b/app/assistants/main-assistant.js
@@ -70,14 +70,14 @@ MainAssistant.prototype.setup = function() {
 	this.controller.setupWidget("teaTypes",
 		{
 			choices: [
-				{label: "Other",  value: 0, time: 0},
-				{label: "Green",  value: 2, time: 2},
-				{label: "Sencha", value: 1, time: 1},
-				{label: "White",  value: 6, time: 6},
-				{label: "Black",  value: 3, time: 3},
-				{label: "Oolong", value: 4, time: 4},
-				{label: "Roibos", value: 5, time: 5},
-				{label: "Puerh",  value: 7, time: 7}
+			        {label: $L("Other"),  value: 0, time: 0},
+			        {label: $L("Green"),  value: 2, time: 2},
+			        {label: $L("Sencha"), value: 1, time: 1},
+			        {label: $L("White"),  value: 6, time: 6},
+			        {label: $L("Black"),  value: 3, time: 3},
+			        {label: $L("Oolong"), value: 4, time: 4},
+			        {label: $L("Roibos"), value: 5, time: 5},
+			        {label: $L("Puerh"),  value: 7, time: 7}
 			],
 			modelProperty: "tea",
 			labelPlacement: Mojo.Widget.labelPlacementLeft,

--- a/appinfo.json
+++ b/appinfo.json
@@ -2,6 +2,7 @@
 	"id": "com.dta3team.webtea",
 	"version": "1.1.7",
 	"vendor": "Dta3 team",
+        "keywords": [ "tea", "timer" ],
 	"type": "web",
 	"main": "index.html",
 	"title": "webTea",

--- a/resources/de_de/appinfo.json
+++ b/resources/de_de/appinfo.json
@@ -1,0 +1,8 @@
+{
+	"id": "com.dta3team.webtea",
+        "title": "webTea",
+        "keywords": [ "Tee", "Uhr", "Timer" ],
+        "main": "../../index.html",
+        "icon": "../../icon.png",
+        "miniicon": "../../miniicon.png"
+}

--- a/resources/de_de/strings.json
+++ b/resources/de_de/strings.json
@@ -1,10 +1,10 @@
 {
-  "Preferences" : "Optionen",
+  "Preferences" : "Einstellungen",
   "Help" : "Hilfe",
   "About" : "Über",
   
   "Time" : "Zeit",
-  "Type" : "Typ",
+  "Type" : "Sorte",
   	"Other" : "Andere",
   	"Green" : "Grün",
         "Sencha": "Sencha",

--- a/resources/de_de/strings.json
+++ b/resources/de_de/strings.json
@@ -7,15 +7,19 @@
   "Type" : "Typ",
   	"Other" : "Andere",
   	"Green" : "Grün",
+        "Sencha": "Sencha",
   	"White" : "Weiß",
   	"Black" : "Schwarz",
+        "Oolong": "Oolong",
+        "Roibos": "Rooibos",
+        "Puerh" : "Pu-Erh",
   "Start" : "Start",
   "Reset" : "Reset",
   "Your Tea is ready to serve!" : "Ihr Tee ist fertig!",
   
   
-  "On" : "On",
-  "Off" : "Off",
+  "On" : "An",
+  "Off" : "Aus",
   "Theme" : "Thema"
   
 }


### PR DESCRIPTION
Hi, I've added keywords to appinfo.json, so that you can “Just Type” the words `tea` or `timer` to start the app.

The list of tea types is now localisable, and I have added/improved the German translation.
